### PR TITLE
Update to 2019.3.2 (2019.3.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM adoptopenjdk/openjdk8
 LABEL maintainer "Viktor Adam <rycus86@gmail.com>"
 
 ARG IDEA_VERSION=2019.3
-ARG IDEA_BUILD=2019.3.1
+ARG IDEA_BUILD=2019.3.2
 
 RUN  \
   apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Version bumped using https://github.com/rycus86/autobump